### PR TITLE
fix(test): silence staticcheck SA5011 after t.Fatal nil-check

### DIFF
--- a/internal/provider/resource_mcp_registry_catalog_item_mapping_test.go
+++ b/internal/provider/resource_mcp_registry_catalog_item_mapping_test.go
@@ -116,6 +116,7 @@ func TestMapCatalogEnterpriseManagedConfig(t *testing.T) {
 		got := mapCatalogEnterpriseManagedConfig(parseCatalogResp(t, body))
 		if got == nil {
 			t.Fatal("got nil, want populated")
+			return
 		}
 		// stringValueOrNull on *string
 		if got.IdentityProviderId.ValueString() != "11111111-1111-1111-1111-111111111111" {


### PR DESCRIPTION
golangci-lint v2.11.4 bumped staticcheck to a version that no longer treats *testing.T.Fatal as flow-terminating, tripping SA5011 in TestMapCatalogEnterpriseManagedConfig. Add an explicit return so the linter can prove the deref is unreachable when got is nil.