### PR TITLE
feat(llm_provider_api_key)!: rename is_organization_default → is_primary; expose is_agent_key

### DIFF
--- a/docs/resources/llm_provider_api_key.md
+++ b/docs/resources/llm_provider_api_key.md
@@ -43,10 +43,10 @@ API key for an LLM provider (OpenAI, Anthropic, etc.). Models are auto-discovere
 # on create and stored encrypted; pass via a TF variable so it never lands
 # in version control.
 resource "archestra_llm_provider_api_key" "inline" {
-  name                    = "Production OpenAI Key"
-  api_key                 = var.openai_api_key
-  llm_provider            = "openai"
-  is_organization_default = true
+  name         = "Production OpenAI Key"
+  api_key      = var.openai_api_key
+  llm_provider = "openai"
+  is_primary   = true
 }
 
 # Vault-backed key — REQUIRED in BYOS mode, accepted in either mode.
@@ -121,7 +121,7 @@ resource "archestra_llm_provider_api_key" "azure_openai" {
 
 - `api_key` (String, Sensitive) The API key value. Mutually exclusive with `vault_secret_path`/`vault_secret_key`. In BYOS (READONLY_VAULT) mode the backend requires the vault pair and rejects inline `api_key`.
 - `base_url` (String) Custom base URL for the LLM provider endpoint
-- `is_organization_default` (Boolean) Whether this API key is the primary key for the provider
+- `is_primary` (Boolean) Whether this API key is the primary key for `(provider, scope)`; a partial unique index on the backend means at most one primary per provider/scope tuple.
 - `scope` (String) Visibility scope for the API key: `personal`, `team`, or `org`
 - `team_id` (String) Team ID for team-scoped keys
 - `vault_secret_key` (String) Key within the vault secret. Must be set together with `vault_secret_path` and cannot be combined with `api_key`.
@@ -130,6 +130,7 @@ resource "archestra_llm_provider_api_key" "azure_openai" {
 ### Read-Only
 
 - `id` (String) LLM Provider API key identifier
+- `is_agent_key` (Boolean) True when the key was minted by a built-in agent's reconfiguration loop. Backend rejects user edits on agent-managed keys; surface this so 403s on `terraform apply` are diagnosable.
 
 ## Import
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -54,7 +54,7 @@ resource "archestra_organization_settings" "main" {
   show_two_factor = true
 
   # Default LLM + agent — cross-refs to our existing resources. Without these
-  # the platform falls back to whichever provider key is is_organization_default.
+  # the platform falls back to whichever provider key is is_primary.
   default_llm_provider   = "ollama"
   default_llm_model      = "llama3"
   default_llm_api_key_id = archestra_llm_provider_api_key.ollama_vault.id

--- a/examples/resources/archestra_llm_provider_api_key/resource.tf
+++ b/examples/resources/archestra_llm_provider_api_key/resource.tf
@@ -28,10 +28,10 @@
 # on create and stored encrypted; pass via a TF variable so it never lands
 # in version control.
 resource "archestra_llm_provider_api_key" "inline" {
-  name                    = "Production OpenAI Key"
-  api_key                 = var.openai_api_key
-  llm_provider            = "openai"
-  is_organization_default = true
+  name         = "Production OpenAI Key"
+  api_key      = var.openai_api_key
+  llm_provider = "openai"
+  is_primary   = true
 }
 
 # Vault-backed key — REQUIRED in BYOS mode, accepted in either mode.

--- a/internal/provider/llm_provider_api_key_helpers.go
+++ b/internal/provider/llm_provider_api_key_helpers.go
@@ -12,7 +12,7 @@ var llmProviderApiKeyAttrSpec = []AttrSpec{
 	{TFName: "name", JSONName: "name", Kind: Scalar},
 	{TFName: "llm_provider", JSONName: "provider", Kind: Scalar},
 	{TFName: "api_key", JSONName: "apiKey", Kind: Scalar, Sensitive: true},
-	{TFName: "is_organization_default", JSONName: "isPrimary", Kind: Scalar},
+	{TFName: "is_primary", JSONName: "isPrimary", Kind: Scalar},
 	{TFName: "base_url", JSONName: "baseUrl", Kind: Scalar},
 	{TFName: "scope", JSONName: "scope", Kind: Scalar},
 	{TFName: "team_id", JSONName: "teamId", Kind: Scalar},
@@ -38,13 +38,17 @@ func (r *LLMProviderApiKeyResource) APIShape() any {
 //     vault_secret_path/vault_secret_key already cover the BYOS path.
 //   - bestModelId: cached "best model" pointer maintained by the backend's
 //     model-discovery scheduler; not part of the user's create/update flow.
-//   - isAgentKey/isSystem: server-side flags that mark special keys
-//     created by built-in agents or system-level integrations; users
-//     don't create these via Terraform.
+//   - isSystem: server-side flag that marks keys created by system-level
+//     integrations; users don't create these via Terraform.
+//
+// `isAgentKey` is exposed as a Computed schema attribute — when it's
+// true, the backend rejects user edits (key is owned by a built-in
+// agent's reconfiguration loop), and surfacing that visibility lets
+// users diagnose rejected applies instead of guessing at 403s.
 func (r *LLMProviderApiKeyResource) KnownIntentionallySkipped() []string {
 	return []string{
 		"createdAt", "updatedAt", "organizationId", "userId", "userName",
 		"teamName", "secretId", "secretStorageType", "bestModelId",
-		"isAgentKey", "isSystem",
+		"isSystem",
 	}
 }

--- a/internal/provider/resource_llm_provider_api_key.go
+++ b/internal/provider/resource_llm_provider_api_key.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -33,16 +34,17 @@ type LLMProviderApiKeyResource struct {
 }
 
 type LLMProviderApiKeyResourceModel struct {
-	ID                    types.String `tfsdk:"id"`
-	Name                  types.String `tfsdk:"name"`
-	ApiKey                types.String `tfsdk:"api_key"`
-	LLMProvider           types.String `tfsdk:"llm_provider"`
-	IsOrganizationDefault types.Bool   `tfsdk:"is_organization_default"`
-	BaseUrl               types.String `tfsdk:"base_url"`
-	Scope                 types.String `tfsdk:"scope"`
-	TeamID                types.String `tfsdk:"team_id"`
-	VaultSecretPath       types.String `tfsdk:"vault_secret_path"`
-	VaultSecretKey        types.String `tfsdk:"vault_secret_key"`
+	ID              types.String `tfsdk:"id"`
+	Name            types.String `tfsdk:"name"`
+	ApiKey          types.String `tfsdk:"api_key"`
+	LLMProvider     types.String `tfsdk:"llm_provider"`
+	IsPrimary       types.Bool   `tfsdk:"is_primary"`
+	BaseUrl         types.String `tfsdk:"base_url"`
+	Scope           types.String `tfsdk:"scope"`
+	TeamID          types.String `tfsdk:"team_id"`
+	VaultSecretPath types.String `tfsdk:"vault_secret_path"`
+	VaultSecretKey  types.String `tfsdk:"vault_secret_key"`
+	IsAgentKey      types.Bool   `tfsdk:"is_agent_key"`
 }
 
 func (r *LLMProviderApiKeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -104,8 +106,8 @@ func (r *LLMProviderApiKeyResource) Schema(ctx context.Context, req resource.Sch
 					),
 				},
 			},
-			"is_organization_default": schema.BoolAttribute{
-				MarkdownDescription: "Whether this API key is the primary key for the provider",
+			"is_primary": schema.BoolAttribute{
+				MarkdownDescription: "Whether this API key is the primary key for `(provider, scope)`; a partial unique index on the backend means at most one primary per provider/scope tuple.",
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
@@ -146,6 +148,11 @@ func (r *LLMProviderApiKeyResource) Schema(ctx context.Context, req resource.Sch
 					stringvalidator.AlsoRequires(path.MatchRoot("vault_secret_path")),
 					stringvalidator.ConflictsWith(path.MatchRoot("api_key")),
 				},
+			},
+			"is_agent_key": schema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "True when the key was minted by a built-in agent's reconfiguration loop. Backend rejects user edits on agent-managed keys; surface this so 403s on `terraform apply` are diagnosable.",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 		},
 	}
@@ -206,8 +213,13 @@ func (r *LLMProviderApiKeyResource) Create(ctx context.Context, req resource.Cre
 	data.ID = types.StringValue(apiResp.JSON200.Id.String())
 	data.Name = types.StringValue(apiResp.JSON200.Name)
 	data.LLMProvider = types.StringValue(string(apiResp.JSON200.Provider))
-	data.IsOrganizationDefault = types.BoolValue(apiResp.JSON200.IsPrimary)
+	data.IsPrimary = types.BoolValue(apiResp.JSON200.IsPrimary)
 	data.Scope = types.StringValue(string(apiResp.JSON200.Scope))
+	// IsAgentKey isn't in the Create response (only the Get echoes
+	// it). A newly user-created key is never an agent-managed key by
+	// definition, so default to false; the next Read will refresh
+	// if the backend ever flips it.
+	data.IsAgentKey = types.BoolValue(false)
 
 	if apiResp.JSON200.BaseUrl != nil {
 		data.BaseUrl = types.StringValue(*apiResp.JSON200.BaseUrl)
@@ -259,8 +271,17 @@ func (r *LLMProviderApiKeyResource) Read(ctx context.Context, req resource.ReadR
 
 	data.Name = types.StringValue(apiResp.JSON200.Name)
 	data.LLMProvider = types.StringValue(string(apiResp.JSON200.Provider))
-	data.IsOrganizationDefault = types.BoolValue(apiResp.JSON200.IsPrimary)
+	data.IsPrimary = types.BoolValue(apiResp.JSON200.IsPrimary)
 	data.Scope = types.StringValue(string(apiResp.JSON200.Scope))
+
+	// IsAgentKey is only present on the Get response (Create / Update
+	// don't echo it). Default to false when missing so the Read-only
+	// projection is stable.
+	if apiResp.JSON200.IsAgentKey != nil {
+		data.IsAgentKey = types.BoolValue(*apiResp.JSON200.IsAgentKey)
+	} else {
+		data.IsAgentKey = types.BoolValue(false)
+	}
 
 	if apiResp.JSON200.BaseUrl != nil {
 		data.BaseUrl = types.StringValue(*apiResp.JSON200.BaseUrl)
@@ -342,7 +363,7 @@ func (r *LLMProviderApiKeyResource) Update(ctx context.Context, req resource.Upd
 
 	data.Name = types.StringValue(apiResp.JSON200.Name)
 	data.LLMProvider = types.StringValue(string(apiResp.JSON200.Provider))
-	data.IsOrganizationDefault = types.BoolValue(apiResp.JSON200.IsPrimary)
+	data.IsPrimary = types.BoolValue(apiResp.JSON200.IsPrimary)
 	data.Scope = types.StringValue(string(apiResp.JSON200.Scope))
 
 	if apiResp.JSON200.BaseUrl != nil {

--- a/internal/provider/resource_llm_provider_api_key_test.go
+++ b/internal/provider/resource_llm_provider_api_key_test.go
@@ -18,7 +18,7 @@ func TestAccLLMProviderApiKeyResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "name", "Test Ollama Key"),
 					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "llm_provider", "ollama"),
-					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "is_organization_default", "false"),
+					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "is_primary", "false"),
 					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "vault_secret_path", "secret/data/test/ollama"),
 					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "vault_secret_key", "api_key"),
 					resource.TestCheckResourceAttrSet("archestra_llm_provider_api_key.test", "id"),
@@ -50,13 +50,13 @@ func TestAccLLMProviderApiKeyResourceWithDefault(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "name", "Default Ollama Key"),
 					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "llm_provider", "ollama"),
-					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "is_organization_default", "true"),
+					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "is_primary", "true"),
 				),
 			},
 			{
 				Config: testAccLLMProviderApiKeyResourceConfig("Default Ollama Key", "ollama", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "is_organization_default", "false"),
+					resource.TestCheckResourceAttr("archestra_llm_provider_api_key.test", "is_primary", "false"),
 				),
 			},
 		},
@@ -122,7 +122,7 @@ func testAccLLMProviderApiKeyResourceConfigWithScope(name string, llmProvider st
 resource "archestra_llm_provider_api_key" "test" {
   name                    = %[1]q
   llm_provider            = %[2]q
-  is_organization_default = false
+  is_primary = false
   scope                   = %[3]q
   vault_secret_path       = "secret/data/test/ollama"
   vault_secret_key        = "api_key"
@@ -136,7 +136,7 @@ func testAccLLMProviderApiKeyResourceConfig(name string, llmProvider string, isD
 resource "archestra_llm_provider_api_key" "test" {
   name                    = %[1]q
   llm_provider            = %[2]q
-  is_organization_default = %[3]t
+  is_primary = %[3]t
   vault_secret_path       = "secret/data/test/ollama"
   vault_secret_key        = "api_key"
 }
@@ -152,7 +152,7 @@ resource "archestra_llm_provider_api_key" "test" {
   name                    = %[1]q
   api_key                 = "test-api-key-value"
   llm_provider            = %[2]q
-  is_organization_default = false
+  is_primary = false
 }
 `, name, llmProvider)
 }


### PR DESCRIPTION
Closes #111.

Renames `archestra_llm_provider_api_key.is_organization_default` → `is_primary` and exposes the previously-hidden `is_agent_key` flag.

The old attribute name implied org-only semantics, but the backend's `isPrimary` field is scope-aware — a partial unique index on `(provider, scope, isPrimary=true)` means it flips primary at any scope (`personal`, `team`, or `org`). Users with team-scoped keys today think the toggle is a no-op.

`is_agent_key` is true on keys minted by built-in agents' reconfiguration loops; the backend rejects user edits on those. Exposing it as a Computed Bool lets users diagnose 403s on `terraform apply` instead of guessing.

### Migration

```diff
 resource \"archestra_llm_provider_api_key\" \"openai\" {
   name         = \"openai-primary\"
   llm_provider = \"openai\"
   api_key      = var.openai_api_key
-  is_organization_default = true
+  is_primary              = true
 }
```

No `terraform state mv` needed — same resource, same wire field. The CHANGELOG is left to release-please, which picks up the `!` marker + `BREAKING:` footer from the commit body.

### Verification

Acceptance tests pass (5/5: happy path, is_primary flip, gemini-shape, invalid-provider, scope variant). Both `examples/basic/` (6 added) and `examples/complete/` (49 added) apply cleanly on a fresh stack with idempotent re-plans and clean destroys.