### PR TITLE
feat(mcp_server_installation): expose install-state observability + enroll TestApiCoverage

### DIFF
--- a/docs/resources/mcp_server_installation.md
+++ b/docs/resources/mcp_server_installation.md
@@ -161,6 +161,11 @@ resource "archestra_mcp_server_installation" "github_vault" {
 
 - `display_name` (String) The actual name of the MCP server installation as returned by the API. The API may append a suffix to ensure uniqueness.
 - `id` (String) MCP server identifier
+- `local_installation_error` (String) Backend-reported install error message when `local_installation_status = error`; null otherwise.
+- `local_installation_status` (String) Terminal install status reported by the backend: `idle`, `pending`, `discovering-tools`, `success`, or `error`.
+- `oauth_refresh_error` (String) OAuth refresh failure mode: `no_refresh_token` or `refresh_failed`; null while credentials are healthy.
+- `oauth_refresh_failed_at` (String) RFC 3339 timestamp of the most recent OAuth refresh failure; null while credentials are healthy.
+- `reinstall_required` (Boolean) True when the backend flagged the install as out-of-date (catalog template changed since install). Surface a reinstall by tainting and re-applying.
 - `tool_id_by_name` (Map of String) Lookup table from each tool's wire name (`<server>__<short>`) to its bare tool UUID — same data as `tools[*].id` but keyed for one-line lookups. Null while tools are still being discovered.
 - `tools` (Attributes List) Tools exposed by the installed MCP server. Populated after install (and refreshed on read) so you can fan out per-tool resources without separate `data "archestra_mcp_server_tool"` lookups:
 

--- a/internal/provider/mcp_server_installation_helpers.go
+++ b/internal/provider/mcp_server_installation_helpers.go
@@ -1,0 +1,33 @@
+package provider
+
+import (
+	"github.com/archestra-ai/archestra/terraform-provider-archestra/internal/client"
+)
+
+// APIShape opts archestra_mcp_server_installation into TestApiCoverage.
+// Returning GetMcpServerResponse{} lets the drift test reflect over the
+// JSON200 body to ensure every wire field is either surfaced as a schema
+// attribute or named in KnownIntentionallySkipped.
+func (r *MCPServerResource) APIShape() any {
+	return client.GetMcpServerResponse{}
+}
+
+// KnownIntentionallySkipped — wire fields not modeled on this resource:
+//   - createdAt/updatedAt: audit timestamps.
+//   - catalogName: backend display sugar (catalog item is referenced by
+//     catalog_id; users already control the name via the catalog item).
+//   - ownerEmail/ownerId/userDetails/users/teamDetails: ownership and
+//     membership metadata; surfacing them would mirror data already
+//     reachable via archestra_organization_members / archestra_team.
+//   - secretStorageType: BYOS/READONLY_VAULT bookkeeping signaling which
+//     secret-manager backend stored the secret; users control storage
+//     via is_byos_vault.
+//   - serverType: catalog-item-derived discriminator (local/remote/etc);
+//     fixed at install time by the chosen catalog item.
+func (r *MCPServerResource) KnownIntentionallySkipped() []string {
+	return []string{
+		"createdAt", "updatedAt", "catalogName",
+		"ownerEmail", "ownerId", "userDetails", "users", "teamDetails",
+		"secretStorageType", "serverType",
+	}
+}

--- a/internal/provider/resource_mcp_server_installation.go
+++ b/internal/provider/resource_mcp_server_installation.go
@@ -89,6 +89,15 @@ type MCPServerResourceModel struct {
 	// instead of either a `data "archestra_mcp_server_tool"` block or a
 	// `for/if` HCL expression over the list.
 	ToolIDByName types.Map `tfsdk:"tool_id_by_name"`
+	// Install-state observability — surfaces the backend's
+	// `localInstallationStatus` / `reinstallRequired` / OAuth refresh
+	// signals so operators can see failed installs and credential drift
+	// without scripting curl against the platform API.
+	ReinstallRequired       types.Bool   `tfsdk:"reinstall_required"`
+	LocalInstallationStatus types.String `tfsdk:"local_installation_status"`
+	LocalInstallationError  types.String `tfsdk:"local_installation_error"`
+	OauthRefreshError       types.String `tfsdk:"oauth_refresh_error"`
+	OauthRefreshFailedAt    types.String `tfsdk:"oauth_refresh_failed_at"`
 }
 
 // mcpServerToolObjectType is the per-element shape of the `tools`
@@ -268,6 +277,26 @@ func (r *MCPServerResource) Schema(ctx context.Context, req resource.SchemaReque
 				Computed:            true,
 				ElementType:         types.StringType,
 			},
+			"reinstall_required": schema.BoolAttribute{
+				MarkdownDescription: "True when the backend flagged the install as out-of-date (catalog template changed since install). Surface a reinstall by tainting and re-applying.",
+				Computed:            true,
+			},
+			"local_installation_status": schema.StringAttribute{
+				MarkdownDescription: "Terminal install status reported by the backend: `idle`, `pending`, `discovering-tools`, `success`, or `error`.",
+				Computed:            true,
+			},
+			"local_installation_error": schema.StringAttribute{
+				MarkdownDescription: "Backend-reported install error message when `local_installation_status = error`; null otherwise.",
+				Computed:            true,
+			},
+			"oauth_refresh_error": schema.StringAttribute{
+				MarkdownDescription: "OAuth refresh failure mode: `no_refresh_token` or `refresh_failed`; null while credentials are healthy.",
+				Computed:            true,
+			},
+			"oauth_refresh_failed_at": schema.StringAttribute{
+				MarkdownDescription: "RFC 3339 timestamp of the most recent OAuth refresh failure; null while credentials are healthy.",
+				Computed:            true,
+			},
 		},
 	}
 }
@@ -408,10 +437,46 @@ func (r *MCPServerResource) Create(ctx context.Context, req resource.CreateReque
 		data.SecretID = types.StringNull()
 	}
 
+	// Seed install-state fields from the InstallMcpServer response so
+	// `reinstall_required` and friends always have a known value even
+	// if the post-wait re-fetch below fails. The install-time snapshot
+	// is the safe fallback — `reinstall_required` is `false` for fresh
+	// installs and OAuth refresh fields are null until the server
+	// starts using credentials.
+	data.ReinstallRequired = types.BoolValue(apiResp.JSON200.ReinstallRequired)
+	data.LocalInstallationStatus = types.StringValue(string(apiResp.JSON200.LocalInstallationStatus))
+	if apiResp.JSON200.LocalInstallationError != nil {
+		data.LocalInstallationError = types.StringValue(*apiResp.JSON200.LocalInstallationError)
+	} else {
+		data.LocalInstallationError = types.StringNull()
+	}
+	if apiResp.JSON200.OauthRefreshError != nil {
+		data.OauthRefreshError = types.StringValue(string(*apiResp.JSON200.OauthRefreshError))
+	} else {
+		data.OauthRefreshError = types.StringNull()
+	}
+	if apiResp.JSON200.OauthRefreshFailedAt != nil {
+		data.OauthRefreshFailedAt = types.StringValue(apiResp.JSON200.OauthRefreshFailedAt.Format(time.RFC3339))
+	} else {
+		data.OauthRefreshFailedAt = types.StringNull()
+	}
+
 	tools, toolIDsByName, toolsDiags := r.waitForServerTools(ctx, apiResp.JSON200.Id.String())
 	resp.Diagnostics.Append(toolsDiags...)
 	data.Tools = tools
 	data.ToolIDByName = toolIDsByName
+
+	// Wait surfaced a hard install error — state won't be written by the
+	// framework, so skip the wasted re-fetch.
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// After waitForServerTools settles, re-fetch the server to overwrite
+	// the install-time snapshot with terminal values (status → success,
+	// reinstall_required refreshed). On fetch failure the seed values
+	// above remain — no Unknown leaks, no phantom null→false diffs.
+	resp.Diagnostics.Append(r.populateInstallState(ctx, apiResp.JSON200.Id, &data)...)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -467,6 +532,24 @@ func (r *MCPServerResource) Read(ctx context.Context, req resource.ReadRequest, 
 		data.SecretID = types.StringValue(apiResp.JSON200.SecretId.String())
 	} else {
 		data.SecretID = types.StringNull()
+	}
+
+	data.ReinstallRequired = types.BoolValue(apiResp.JSON200.ReinstallRequired)
+	data.LocalInstallationStatus = types.StringValue(string(apiResp.JSON200.LocalInstallationStatus))
+	if apiResp.JSON200.LocalInstallationError != nil {
+		data.LocalInstallationError = types.StringValue(*apiResp.JSON200.LocalInstallationError)
+	} else {
+		data.LocalInstallationError = types.StringNull()
+	}
+	if apiResp.JSON200.OauthRefreshError != nil {
+		data.OauthRefreshError = types.StringValue(string(*apiResp.JSON200.OauthRefreshError))
+	} else {
+		data.OauthRefreshError = types.StringNull()
+	}
+	if apiResp.JSON200.OauthRefreshFailedAt != nil {
+		data.OauthRefreshFailedAt = types.StringValue(apiResp.JSON200.OauthRefreshFailedAt.Format(time.RFC3339))
+	} else {
+		data.OauthRefreshFailedAt = types.StringNull()
 	}
 
 	// EnvironmentValues, UserConfigValues, and AccessToken are write-only;
@@ -558,6 +641,44 @@ func (r *MCPServerResource) ImportState(ctx context.Context, req resource.Import
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), parts[1])...)
+}
+
+// populateInstallState re-fetches the server post-install to capture
+// terminal `reinstall_required`, `local_installation_status/_error`, and
+// `oauth_refresh_*` values from the authoritative GetMcpServer endpoint.
+// Used at the tail of Create so the state row reflects the settled
+// install. On fetch failure, leaves the fields untouched (Create seeds
+// them from the InstallMcpServer response first) and surfaces a warning
+// — Read will refresh them on the next plan.
+func (r *MCPServerResource) populateInstallState(ctx context.Context, serverID openapi_types.UUID, data *MCPServerResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+	apiResp, err := r.client.GetMcpServerWithResponse(ctx, serverID)
+	if err != nil {
+		diags.AddWarning("Install-state refresh failed", err.Error())
+		return diags
+	}
+	if apiResp.JSON200 == nil {
+		diags.AddWarning("Install-state refresh failed", fmt.Sprintf("unexpected response status %d: %s", apiResp.StatusCode(), string(apiResp.Body)))
+		return diags
+	}
+	data.ReinstallRequired = types.BoolValue(apiResp.JSON200.ReinstallRequired)
+	data.LocalInstallationStatus = types.StringValue(string(apiResp.JSON200.LocalInstallationStatus))
+	if apiResp.JSON200.LocalInstallationError != nil {
+		data.LocalInstallationError = types.StringValue(*apiResp.JSON200.LocalInstallationError)
+	} else {
+		data.LocalInstallationError = types.StringNull()
+	}
+	if apiResp.JSON200.OauthRefreshError != nil {
+		data.OauthRefreshError = types.StringValue(string(*apiResp.JSON200.OauthRefreshError))
+	} else {
+		data.OauthRefreshError = types.StringNull()
+	}
+	if apiResp.JSON200.OauthRefreshFailedAt != nil {
+		data.OauthRefreshFailedAt = types.StringValue(apiResp.JSON200.OauthRefreshFailedAt.Format(time.RFC3339))
+	} else {
+		data.OauthRefreshFailedAt = types.StringNull()
+	}
+	return diags
 }
 
 // waitForServerTools polls `/installation-status` until terminal, then

--- a/internal/provider/resource_mcp_server_installation_test.go
+++ b/internal/provider/resource_mcp_server_installation_test.go
@@ -154,6 +154,37 @@ func TestAccMCPServerInstallationResource(t *testing.T) {
 						tfjsonpath.New("tool_id_by_name"),
 						knownvalue.NotNull(),
 					),
+					// Install-state observability — happy path. Failed
+					// installs surface via Create-time error diagnostic
+					// (state is never written), so the regression
+					// coverage is on the success-state shape: status
+					// settled to "success", reinstall_required false, no
+					// OAuth refresh errors.
+					statecheck.ExpectKnownValue(
+						"archestra_mcp_server_installation.test",
+						tfjsonpath.New("local_installation_status"),
+						knownvalue.StringExact("success"),
+					),
+					statecheck.ExpectKnownValue(
+						"archestra_mcp_server_installation.test",
+						tfjsonpath.New("local_installation_error"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"archestra_mcp_server_installation.test",
+						tfjsonpath.New("reinstall_required"),
+						knownvalue.Bool(false),
+					),
+					statecheck.ExpectKnownValue(
+						"archestra_mcp_server_installation.test",
+						tfjsonpath.New("oauth_refresh_error"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"archestra_mcp_server_installation.test",
+						tfjsonpath.New("oauth_refresh_failed_at"),
+						knownvalue.Null(),
+					),
 				},
 			},
 			// Re-apply with identical config — pins the `tools` list-ordering


### PR DESCRIPTION
Closes #113.

Adds five Computed attributes to `archestra_mcp_server_installation` derived from `GET /api/mcp_server/:id`:

- `local_installation_status` — `idle` / `pending` / `discovering-tools` / `success` / `error`
- `local_installation_error` — backend message when status = error; null otherwise
- `reinstall_required` — true when the catalog template changed since install
- `oauth_refresh_error` — `no_refresh_token` / `refresh_failed`; null while healthy
- `oauth_refresh_failed_at` — RFC 3339 timestamp of last refresh failure; null while healthy

Also enrolls the resource in `TestApiCoverage` via `APIShape()` + `KnownIntentionallySkipped()`, so future wire-field additions surface as a drift-lint failure.

One non-obvious bit worth flagging: **Create seeds the install-state fields from the `InstallMcpServer` response** (the snapshot the backend returns immediately), then re-fetches via `GetMcpServer` after `waitForServerTools` settles to overwrite with terminal values. The seed-then-refresh dance means that if the post-wait `GetMcpServer` ever fails, the install-time snapshot stays — no Unknown leaks into state, no phantom `null → false` diffs on the next refresh.

### Verification

Acceptance tests pass: `TestAccMCPServerInstallationResource` (happy path, idempotent re-apply, composite-import contract, with new `statecheck` assertions on each of the 5 fields) and `TestDecideInstallStatus` (pure state-machine unit test). Drift-check lints (`TestSpecDrift`, `TestApiCoverage`) cover the new attributes.

`examples/complete/` applies cleanly on a fresh stack with `local_installation_status = "success"` and `reinstall_required = false` reflected in state for `archestra_mcp_server_installation.filesystem`.
