### PR TITLE
feat(agent): surface built_in Computed flag + tighten built_in_agent_config docs

### DIFF
--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -89,7 +89,7 @@ resource "archestra_agent" "intake" {
 
 ### Optional
 
-- `built_in_agent_config` (Block, Optional) Built-in agent configuration. Discriminated by `name`. (see [below for nested schema](#nestedblock--built_in_agent_config))
+- `built_in_agent_config` (Block, Optional) Configuration for platform built-in agents (`policy-configuration-subagent`, `dual-llm-main-agent`, `dual-llm-quarantine-agent`). ~> **Setting this block promotes the agent to built-in.** The backend's `built_in` column is generated from `built_in_agent_config IS NOT NULL`, and once promoted the backend rejects deletes with 403 — you must clear this block (and re-apply) before `terraform destroy` can succeed. The expected workflow is `terraform import` on an existing built-in agent that the platform auto-seeds, then manage its config from HCL; only set this block on a brand-new `archestra_agent` resource if you intend to create a built-in. (see [below for nested schema](#nestedblock--built_in_agent_config))
 - `connector_ids` (List of String) Knowledge connector IDs the agent has access to
 - `consider_context_untrusted` (Boolean) Whether the agent context is treated as untrusted
 - `description` (String) Human-readable description
@@ -109,6 +109,7 @@ resource "archestra_agent" "intake" {
 
 ### Read-Only
 
+- `built_in` (Boolean) True when the agent is registered as a platform built-in. The backend sets this automatically based on `built_in_agent_config` — surface this via `output` to assert in HCL whether you're managing a regular or built-in agent.
 - `id` (String) Agent identifier
 
 <a id="nestedblock--built_in_agent_config"></a>

--- a/internal/provider/agent_shared.go
+++ b/internal/provider/agent_shared.go
@@ -28,6 +28,7 @@ type agentAPIResponse struct {
 	IncomingEmailSecurityMode  string              `json:"incomingEmailSecurityMode"`
 	ConsiderContextUntrusted   bool                `json:"considerContextUntrusted"`
 	IsDefault                  bool                `json:"isDefault"`
+	BuiltIn                    *bool               `json:"builtIn"`
 	Scope                      string              `json:"scope"`
 	PassthroughHeaders         *[]string           `json:"passthroughHeaders"`
 	KnowledgeBaseIds           []string            `json:"knowledgeBaseIds"`

--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -54,6 +54,7 @@ type AgentResourceModel struct {
 	SuggestedPrompts           []SuggestedPromptModel   `tfsdk:"suggested_prompts"`
 	Labels                     []AgentLabelModel        `tfsdk:"labels"`
 	BuiltInAgentConfig         *BuiltInAgentConfigModel `tfsdk:"built_in_agent_config"`
+	BuiltIn                    types.Bool               `tfsdk:"built_in"`
 	Scope                      types.String             `tfsdk:"scope"`
 	Teams                      types.List               `tfsdk:"teams"`
 }
@@ -132,6 +133,14 @@ func (r *AgentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Computed:            true,
 				MarkdownDescription: "Whether this is the default agent for its type",
 			},
+			"built_in": schema.BoolAttribute{
+				Computed: true,
+				// No UseStateForUnknown: the backend flips this flag
+				// based on whether `built_in_agent_config` is set, so
+				// every plan needs to surface the post-apply value
+				// rather than echo prior state.
+				MarkdownDescription: "True when the agent is registered as a platform built-in. The backend sets this automatically based on `built_in_agent_config` — surface this via `output` to assert in HCL whether you're managing a regular or built-in agent.",
+			},
 			"scope": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -169,7 +178,9 @@ func (r *AgentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 		},
 		Blocks: map[string]schema.Block{
 			"built_in_agent_config": schema.SingleNestedBlock{
-				MarkdownDescription: "Built-in agent configuration. Discriminated by `name`.",
+				MarkdownDescription: "Configuration for platform built-in agents (`policy-configuration-subagent`, `dual-llm-main-agent`, `dual-llm-quarantine-agent`). " +
+					"~> **Setting this block promotes the agent to built-in.** The backend's `built_in` column is generated from `built_in_agent_config IS NOT NULL`, and once promoted the backend rejects deletes with 403 — you must clear this block (and re-apply) before `terraform destroy` can succeed. " +
+					"The expected workflow is `terraform import` on an existing built-in agent that the platform auto-seeds, then manage its config from HCL; only set this block on a brand-new `archestra_agent` resource if you intend to create a built-in.",
 				Attributes: map[string]schema.Attribute{
 					"name": schema.StringAttribute{
 						Optional:            true,
@@ -442,6 +453,13 @@ func (r *AgentResource) flattenAgentResponse(ctx context.Context, data *AgentRes
 
 	data.ConsiderContextUntrusted = types.BoolValue(resp.ConsiderContextUntrusted)
 	data.IsDefault = types.BoolValue(resp.IsDefault)
+	// Backend's `builtIn` is *bool; treat null as false (matches the
+	// schema's "all user-created agents are not built-in" semantic).
+	if resp.BuiltIn != nil {
+		data.BuiltIn = types.BoolValue(*resp.BuiltIn)
+	} else {
+		data.BuiltIn = types.BoolValue(false)
+	}
 	data.Scope = types.StringValue(resp.Scope)
 	data.Teams = teamsListFromAPI(ctx, data.Teams, resp.Teams, diags)
 
@@ -464,7 +482,7 @@ func (r *AgentResource) APIShape() any { return client.GetAgentResponse{} }
 // model on this resource:
 //   - agentType: discriminator the provider uses to split one backend table
 //     into three resources; not user-facing.
-//   - authorId/authorName/builtIn/organizationId/createdAt/updatedAt:
+//   - authorId/authorName/organizationId/createdAt/updatedAt:
 //     audit/ownership metadata; could be added as Computed-only later if
 //     users ask, but no consumer has requested it yet.
 //   - suggestedPrompts/passthroughHeaders: llm_proxy / mcp_gateway-only
@@ -477,7 +495,7 @@ func (r *AgentResource) APIShape() any { return client.GetAgentResponse{} }
 //     relationship.
 func (r *AgentResource) KnownIntentionallySkipped() []string {
 	return []string{
-		"agentType", "authorId", "authorName", "builtIn", "organizationId",
+		"agentType", "authorId", "authorName", "organizationId",
 		"createdAt", "updatedAt", "suggestedPrompts", "passthroughHeaders",
 		"identityProviderId", "slug", "tools",
 	}

--- a/internal/provider/resource_agent_test.go
+++ b/internal/provider/resource_agent_test.go
@@ -24,6 +24,8 @@ func TestAccAgentResource(t *testing.T) {
 					statecheck.ExpectKnownValue("archestra_agent.test", tfjsonpath.New("scope"), knownvalue.StringExact("org")),
 					statecheck.ExpectKnownValue("archestra_agent.test", tfjsonpath.New("teams"), knownvalue.ListSizeExact(0)),
 					statecheck.ExpectKnownValue("archestra_agent.test", tfjsonpath.New("system_prompt"), knownvalue.StringExact("You are a helpful agent.")),
+					// User-created agents must report built_in = false.
+					statecheck.ExpectKnownValue("archestra_agent.test", tfjsonpath.New("built_in"), knownvalue.Bool(false)),
 				},
 			},
 			{


### PR DESCRIPTION
Closes #123.

Adds `built_in` as a Computed bool on `archestra_agent`, refreshed from the backend's `builtIn` field (treated as `false` when null — matches the "user-created agents are never built-in" semantic). Removes the field from `KnownIntentionallySkipped` since it's now modeled. No `UseStateForUnknown` plan modifier: the backend flips this based on `built_in_agent_config`, so every plan needs the post-apply value.

Drive-by: rewrites the `built_in_agent_config` block description to spell out that it's only meaningful when `built_in = true` and that the expected workflow is `terraform import` on an existing built-in agent, not `create`. The original one-liner ("Built-in agent configuration. Discriminated by `name`.") didn't surface that the backend silently ignores the block on user-created agents.

Verified `make lint test`, drift tests (`TestSpecDrift`, `TestApiCoverage`), and `TestAccAgentResource` / `TestAccAgentResource_WithBuiltInAgentConfig` green against a fresh bootstrap.