### PR TITLE
feat(crossplane): seed initial release at v1.0.0

### DIFF
--- a/crossplane/CHANGELOG.md
+++ b/crossplane/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog


### PR DESCRIPTION
The Crossplane provider was collapsed into the monorepo in #92 as a chore, so release-please has had no release-triggering commit to attribute to the `crossplane` component. Seeds an empty CHANGELOG release-please will own going forward, and pins the first release to v1.0.0 to track the Terraform provider's existing baseline.

Release-As: 1.0.0