### PR TITLE
fix(ci): authenticate to Upbound via docker login, not up login

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -133,21 +133,27 @@ jobs:
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest
 
-      - name: Install Upbound CLI
+      - name: Log in to Upbound registry
+        # `make publish` shells out to `crank xpkg push`, which is a Docker
+        # registry push — it reads creds from ~/.docker/config.json, not from
+        # the Upbound CLI's session. Robot tokens are also not valid for
+        # `up login --token` (that flag expects a user PAT).
+        env:
+          UPBOUND_ACCESS_ID: ${{ secrets.UPBOUND_ACCESS_ID }}
+          UPBOUND_TOKEN: ${{ secrets.UPBOUND_TOKEN }}
         run: |
-          curl -sL https://cli.upbound.io | sh
-          sudo mv up /usr/local/bin/
+          set -euo pipefail
+          echo "$UPBOUND_TOKEN" | docker login xpkg.upbound.io \
+            --username "$UPBOUND_ACCESS_ID" --password-stdin
 
       - name: Build and publish provider package
         env:
-          UP_TOKEN: ${{ secrets.UPBOUND_TOKEN }}
           TAG: ${{ needs.release-please.outputs.crossplane_tag_name }}
         run: |
           set -euo pipefail
           # release-please tags the Crossplane package crossplane-vX.Y.Z;
           # the xpkg is published as vX.Y.Z.
           VERSION="${TAG#crossplane-}"
-          up login --token "$UP_TOKEN"
           make -C crossplane generate
           make -C crossplane build publish \
             XPKG_REG_ORGS="xpkg.upbound.io/archestra" \


### PR DESCRIPTION
## Summary
- `make publish` shells out to `crank xpkg push`, which is a Docker registry push and reads creds from `~/.docker/config.json` — not from the Upbound CLI's session.
- On top of that, `up login --token` expects a user PAT and rejects robot-token JWTs with HTTP 401, which is exactly what the first `crossplane-v1.0.0` publish run hit.
- Replaces `up login` with `docker login xpkg.upbound.io`, splitting credentials into `UPBOUND_ACCESS_ID` (robot accessId, used as username) + `UPBOUND_TOKEN` (robot JWT, used as password). Drops the Upbound CLI install step since nothing else needs the `up` binary.

## Test plan
- [ ] Merge to main.
- [ ] Re-run the failed `Publish Crossplane Provider` job on the existing run for tag `crossplane-v1.0.0` and confirm `docker login` succeeds and `crank xpkg push` uploads the multi-arch xpkg to `xpkg.upbound.io/archestra/crossplane-provider-archestra:v1.0.0`.