### PR TITLE
fix(crossplane): point install example at the real registry

### DIFF
--- a/crossplane/README.md
+++ b/crossplane/README.md
@@ -25,12 +25,12 @@ kind: Provider
 metadata:
   name: crossplane-provider-archestra
 spec:
-  package: ghcr.io/archestra-ai/crossplane-provider-archestra:v0.1.0
+  package: xpkg.upbound.io/archestra/crossplane-provider-archestra:v1.0.0
 EOF
 ```
 
-Adjust the `package:` path to whichever registry you publish to (GHCR,
-`xpkg.upbound.io/archestra-ai/...`, etc.).
+Replace the tag with the latest release from
+[GitHub Releases](https://github.com/archestra-ai/terraform-provider-archestra/releases?q=crossplane-).
 
 ## Configure credentials
 


### PR DESCRIPTION
## Summary
- The README install snippet referenced \`ghcr.io/archestra-ai/crossplane-provider-archestra:v0.1.0\`, which was wrong on both axes — the xpkg is actually published to \`xpkg.upbound.io/archestra\` and the v0.1.0 placeholder predates the v1.0.0 release.
- Points the snippet at the real registry path and replaces the stale "Adjust the path" hint with a pointer to GitHub Releases for tag lookup.
- Side effect (intentional): a \`fix(crossplane):\` commit lands on main so release-please opens a v1.0.1 release PR. Merging that bumps the manifest and re-triggers the publish job — which will now run against the docker-login workflow (#131) instead of the failed \`up login\` one, giving us the first actually-pushed xpkg.

## Test plan
- [ ] Merge.
- [ ] Confirm release-please opens \`chore(main): release crossplane 1.0.1\`.
- [ ] Merge that PR and confirm Publish Crossplane Provider pushes \`xpkg.upbound.io/archestra/crossplane-provider-archestra:v1.0.1\` successfully.