### PR TITLE
fix(ci): read release-please outputs without .-- namespace prefix

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,9 +27,9 @@ jobs:
       issues: write # label release PRs
       id-token: write # OIDC for action identity
     outputs:
-      # Manifest mode -> outputs are path-namespaced.
-      release_created: ${{ steps.release-please.outputs['.--release_created'] }}
-      tag_name: ${{ steps.release-please.outputs['.--tag_name'] }}
+      # Single-package manifest mode -> outputs are flat (no `<path>--` prefix).
+      release_created: ${{ steps.release-please.outputs.release_created }}
+      tag_name: ${{ steps.release-please.outputs.tag_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

PR #135 (unification) left the workflow's output references in the two-package form (\`steps.release-please.outputs['.--release_created']\`), but with single-package manifest mode \`release-please-action\` emits **flat** outputs without the \`<path>--\` prefix. The mismatch made every \`needs.release-please.outputs.release_created\` read evaluate to an empty string, so both \`publish-terraform-provider\` and \`publish-crossplane\` silently skipped on v1.1.2 ([run 26312551367](https://github.com/archestra-ai/terraform-provider-archestra/actions/runs/26312551367)).

You can confirm the missing namespace by reading the \`Log release-please outputs\` step of that run — the OUTPUTS JSON only contains \`release_created\`, \`tag_name\`, etc., never \`.--release_created\`.

## Fix

Drop the \`.--\` prefix from both output references in the \`release-please\` job's \`outputs:\` block.

## Why v1.1.2 won't auto-publish even after this merges

Re-running run 26312551367 would replay it against the workflow at the v1.1.2 SHA, which still has the bug. To publish v1.1.2 we'd need to either (a) push a one-off manual goreleaser/xpkg job locally, or (b) wait for the next release-please cycle. Easiest path: merge this, and the next \`fix:\` / \`feat:\` commit cuts v1.1.3 (or higher) and exercises the corrected workflow end-to-end.

## Test plan

- [ ] Merge.
- [ ] Next release on main triggers both \`Publish Terraform Provider\` and \`Publish Crossplane Provider\` against the same \`vX.Y.Z\` tag.
- [ ] Confirm the xpkg lands at \`xpkg.upbound.io/archestra/provider-archestra:vX.Y.Z\` and goreleaser produces signed binaries on the GitHub Release.