### PR TITLE
fix(ci): build both linux archs before pushing the xpkg

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -149,7 +149,11 @@ jobs:
           VERSION: ${{ needs.release-please.outputs.tag_name }}
         run: |
           set -euo pipefail
+          # `make build` only builds for the host arch via BUILD_PLATFORMS;
+          # `build.all` honors PLATFORMS so both linux_amd64 and linux_arm64
+          # xpkgs are produced — `crank xpkg push` needs both.
           make -C crossplane generate
-          make -C crossplane build publish \
+          make -C crossplane build.all publish \
+            PLATFORMS="linux_amd64 linux_arm64" \
             XPKG_REG_ORGS="xpkg.upbound.io/archestra" \
             VERSION="$VERSION"


### PR DESCRIPTION
## Summary

The Crossplane publish job builds a single \`linux_amd64\` xpkg but then \`crank xpkg push\` is invoked with \`--package-files\` for **both** \`linux_amd64\` and \`linux_arm64\`. The arm64 file doesn't exist, so the push fails — that's what blocked v1.1.3 ([run 26312790429](https://github.com/archestra-ai/terraform-provider-archestra/actions/runs/26312790429/job/77465306810)):

\`\`\`
crossplane: error: --package-files: stat .../crossplane/_output/xpkg/linux_arm64/provider-archestra-v1.1.3.xpkg: no such file or directory
\`\`\`

## Root cause

\`crossplane/build/makelib/common.mk\`:

\`\`\`makefile
# build for all platforms
build.all:
    ...

# build for a single platform if it's supported
build:
ifneq ($(BUILD_PLATFORMS),)
    @$(MAKE) build.all PLATFORMS=\"$(BUILD_PLATFORMS)\"   # host arch only
\`\`\`

\`BUILD_PLATFORMS\` defaults to \`linux_$(TARGETARCH)\`, so on a GitHub amd64 runner \`make build\` only ever produces \`linux_amd64\`. The \`xpkg.mk\` push target, however, fans out across every entry in \`XPKG_LINUX_PLATFORMS\` (also defaults to both archs).

## Fix

Switch the publish step from \`make build\` → \`make build.all\` with \`PLATFORMS=\"linux_amd64 linux_arm64\"\` so both archs are produced before \`make publish\` runs. QEMU + buildx are already set up earlier in the job (lines 114–123), so arm64 cross-compilation works on the amd64 runner via emulation.

## Test plan

- [ ] Merge.
- [ ] Next release triggers a Crossplane publish run that:
  - Builds both \`provider-archestra-vX.Y.Z.xpkg\` files under \`crossplane/_output/xpkg/linux_amd64/\` and \`.../linux_arm64/\`.
  - Pushes a multi-arch \`xpkg.upbound.io/archestra/provider-archestra:vX.Y.Z\` (visible as two manifests under one tag in the Upbound console).