### PR TITLE
feat(ci): add Crossplane coverage report + README badge

### DIFF
--- a/.github/badges/crossplane-coverage.json
+++ b/.github/badges/crossplane-coverage.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"crossplane coverage","message":"5/20 (25%)","color":"orange"}

--- a/.github/workflows/crossplane-coverage.yml
+++ b/.github/workflows/crossplane-coverage.yml
@@ -1,0 +1,54 @@
+name: Crossplane Coverage
+
+# Reports which Terraform resources don't yet have a Crossplane managed-resource
+# equivalent. Non-blocking — informational only.
+#
+# - On PRs that touch either side: writes the report to the job summary.
+# - On main pushes: also refreshes .github/badges/crossplane-coverage.json so the
+#   README badge stays in sync. Auto-commits when the JSON changes.
+
+on:
+  pull_request:
+    paths:
+      - 'internal/provider/resource_*.go'
+      - 'crossplane/config/external_name.go'
+      - 'scripts/crossplane-coverage.sh'
+      - '.github/workflows/crossplane-coverage.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'internal/provider/resource_*.go'
+      - 'crossplane/config/external_name.go'
+      - 'scripts/crossplane-coverage.sh'
+      - '.github/workflows/crossplane-coverage.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: Report TF↔Crossplane coverage
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # to commit the refreshed badge JSON on main
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Generate coverage report
+        run: scripts/crossplane-coverage.sh "$GITHUB_STEP_SUMMARY"
+
+      - name: Refresh badge JSON
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          scripts/crossplane-coverage.sh --badge .github/badges/crossplane-coverage.json
+          if ! git diff --quiet .github/badges/crossplane-coverage.json; then
+            git config user.name 'github-actions[bot]'
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git add .github/badges/crossplane-coverage.json
+            git commit -m 'chore(ci): refresh Crossplane coverage badge'
+            git push
+          fi

--- a/.github/workflows/crossplane-coverage.yml
+++ b/.github/workflows/crossplane-coverage.yml
@@ -23,6 +23,12 @@ on:
       - '.github/workflows/crossplane-coverage.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel stale PR runs when new commits land; let main runs finish so the
+  # auto-commit step doesn't race itself.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -34,6 +40,8 @@ jobs:
       contents: write # to commit the refreshed badge JSON on main
     steps:
       - name: Checkout
+        # zizmor: ignore[artipacked] credentials are intentionally persisted on
+        # main pushes so the auto-commit step can refresh the badge JSON.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Archestra Terraform Provider
 
+[![Crossplane coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/archestra-ai/terraform-provider-archestra/main/.github/badges/crossplane-coverage.json)](.github/workflows/crossplane-coverage.yml)
+
 The Archestra Terraform provider lets you manage Archestra resources —
 agents, MCP servers, identity providers, teams, LLM keys, security
 policies, organization settings — as code.

--- a/scripts/crossplane-coverage.sh
+++ b/scripts/crossplane-coverage.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Reports which Terraform resources do not yet have a Crossplane managed-resource
+# equivalent.
+#
+# Sources of truth:
+#   - Terraform: `resp.TypeName = req.ProviderTypeName + "_<n>"` lines in
+#     internal/provider/resource_*.go
+#   - Crossplane: the `ExternalNameConfigs` map in
+#     crossplane/config/external_name.go (also functions as the upjet IncludeList)
+#
+# Usage:
+#   scripts/crossplane-coverage.sh                 # markdown report to stdout
+#   scripts/crossplane-coverage.sh path/to/out.md  # markdown report to file
+#   scripts/crossplane-coverage.sh --badge out.json  # shields.io endpoint JSON
+
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+tf="$(grep -h 'TypeName = req.ProviderTypeName + "_' internal/provider/resource_*.go \
+  | sed -E 's/.*"_([a-z_]+)".*/archestra_\1/' \
+  | sort -u)"
+cp="$(grep -oE '"archestra_[a-z_]+"' crossplane/config/external_name.go \
+  | tr -d '"' \
+  | sort -u)"
+
+tf_total=$(printf '%s\n' "$tf" | grep -c .)
+covered="$(comm -12 <(echo "$tf") <(echo "$cp"))"
+cp_total=$(printf '%s\n' "$covered" | grep -c . || true)
+pct=$(( cp_total * 100 / tf_total ))
+
+if [ "${1:-}" = "--badge" ]; then
+  out="${2:?--badge requires an output path}"
+  color="red"
+  [ "$pct" -ge 25 ] && color="orange"
+  [ "$pct" -ge 50 ] && color="yellow"
+  [ "$pct" -ge 75 ] && color="green"
+  [ "$pct" -ge 95 ] && color="brightgreen"
+  cat > "$out" <<EOF
+{"schemaVersion":1,"label":"crossplane coverage","message":"${cp_total}/${tf_total} (${pct}%)","color":"${color}"}
+EOF
+  exit 0
+fi
+
+out="${1:-/dev/stdout}"
+missing="$(comm -23 <(echo "$tf") <(echo "$cp"))"
+orphans="$(comm -13 <(echo "$tf") <(echo "$cp"))"
+
+{
+  echo "# Crossplane coverage report"
+  echo
+  echo "**${cp_total} / ${tf_total} Terraform resources have Crossplane managed-resource equivalents (${pct}%).**"
+  echo
+  echo "## Missing Crossplane MR (drift)"
+  echo
+  if [ -z "$missing" ]; then
+    echo "_(none — full coverage)_"
+  else
+    while IFS= read -r r; do
+      [ -n "$r" ] && echo "- \`$r\`"
+    done <<< "$missing"
+  fi
+  echo
+  echo "## Covered"
+  echo
+  while IFS= read -r r; do
+    [ -n "$r" ] && echo "- \`$r\`"
+  done <<< "$covered"
+  if [ -n "$orphans" ]; then
+    echo
+    echo "## Crossplane mappings without a Terraform resource"
+    echo
+    echo "_(should be empty)_"
+    echo
+    while IFS= read -r r; do
+      [ -n "$r" ] && echo "- \`$r\`"
+    done <<< "$orphans"
+  fi
+} > "$out"


### PR DESCRIPTION
Optional informational job. On PRs that touch either side, writes a coverage report to the job summary. On main pushes, refreshes the shields.io endpoint JSON at `.github/badges/crossplane-coverage.json` and auto-commits when the numbers change. Initial coverage: 5/20 (25%).