### PR TITLE
fix(provider): treat empty ID in Read as "not yet created"

### DIFF
--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -256,6 +256,10 @@ func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	if data.ID.IsNull() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	id, err := uuid.Parse(data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid ID", fmt.Sprintf("Unable to parse agent ID: %s", err))

--- a/internal/provider/resource_agent_tool_batch.go
+++ b/internal/provider/resource_agent_tool_batch.go
@@ -144,6 +144,11 @@ func (r *AgentToolBatchResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	if data.AgentID.IsNull() || data.AgentID.ValueString() == "" ||
+		data.McpServerID.IsNull() || data.McpServerID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	agentUUID, err := uuid.Parse(data.AgentID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid agent_id", err.Error())

--- a/internal/provider/resource_mcp_registry_catalog_item.go
+++ b/internal/provider/resource_mcp_registry_catalog_item.go
@@ -1292,6 +1292,13 @@ func (r *MCPServerRegistryResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
+	// Empty/null ID means the resource has not been created yet (e.g. upjet
+	// seeds Terraform state with id="" before the first reconcile). Treat as
+	// "doesn't exist" — terraform/upjet will plan a Create on the next pass.
+	if data.ID.IsNull() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	// Parse UUID from state
 	serverID, err := uuid.Parse(data.ID.ValueString())
 	if err != nil {

--- a/internal/provider/resource_mcp_server_installation.go
+++ b/internal/provider/resource_mcp_server_installation.go
@@ -423,6 +423,10 @@ func (r *MCPServerResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	if data.ID.IsNull() || data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	// Parse UUID from state
 	serverID, err := uuid.Parse(data.ID.ValueString())
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of 96c3b97 from \`fix/v1.2.20-review-followups\` — the bug stayed un-merged on that long-running branch.

## Problem

Direct Terraform never calls Read with an empty ID (it only runs Read after Create has assigned one), so `uuid.Parse("")` returning "Invalid ID: invalid UUID length: 0" was harmless for the TF use case. **upjet does call it though** — it seeds the per-resource Terraform workspace with `id=""` and runs `terraform refresh` before `apply`. The strict UUID parse failed and the Crossplane controller never advanced to Create.

Reproduced live against `xpkg.upbound.io/archestra/provider-archestra:v1.1.4` in `scratch-test-crossplane` — every Crossplane MR stuck on:

```
observe failed: cannot run refresh: refresh failed: Invalid ID: Unable to parse <resource> ID: invalid UUID length: 0
```

## Fix

In Read, when ID is null/empty, drop the resource from state (`resp.State.RemoveResource(ctx)`) and return without error. Terraform re-plans a Create on the next pass — same pattern AWS/GCP TF providers use.

Applied to the four resources whose Read parses a single UUID (or pair of UUIDs) up front:

- `archestra_mcp_registry_catalog_item`
- `archestra_mcp_server_installation`
- `archestra_agent`
- `archestra_agent_tool_batch` (tolerates either `agent_id` or `mcp_server_id` being empty)

`archestra_tool_invocation_policy_default` is unaffected — its Read walks `ToolIDs` (a list) and an empty list is already a benign no-op.

## Test plan

- [x] Unblocks Crossplane reconcile in `scratch-test-crossplane` (verified by the original commit author).
- [ ] After this merges + a new release ships, redeploy the three MRs (`RegistryCatalogItem`/`ServerInstallation`/`Agent`) into `scratch-test-crossplane` and confirm Synced=True, Ready=True.

A Plugin Framework Read unit test that asserts an empty-ID state becomes a removed-resource state without diagnostics is the right regression cover. Flagged as a follow-up by the original commit since the suite has no precedent for direct Read invocation.