### PR TITLE
docs: add Resource coverage table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,37 @@ schema and shipped together on every `vX.Y.Z` tag:
 End users install from those. This README walks a new contributor
 through extending the provider.
 
+## Resource coverage
+
+| Terraform resource | Crossplane Kind |
+|---|---|
+| `archestra_agent` | `Agent` |
+| `archestra_agent_tool` | — |
+| `archestra_agent_tool_batch` | `ToolBatch` |
+| `archestra_identity_provider` | — |
+| `archestra_limit` | — |
+| `archestra_llm_model` | — |
+| `archestra_llm_provider_api_key` | — |
+| `archestra_llm_proxy` | — |
+| `archestra_mcp_gateway` | — |
+| `archestra_mcp_registry_catalog_item` | `RegistryCatalogItem` |
+| `archestra_mcp_server_installation` | `ServerInstallation` |
+| `archestra_optimization_rule` | — |
+| `archestra_organization_settings` | — |
+| `archestra_team` | — |
+| `archestra_team_external_group` | — |
+| `archestra_tool_invocation_policy` | — |
+| `archestra_tool_invocation_policy_default` | `ToolInvocationPolicyDefault` |
+| `archestra_tool_policy_auto_config` | — |
+| `archestra_trusted_data_policy` | — |
+| `archestra_trusted_data_policy_default` | — |
+
+`—` means the resource is implemented for Terraform but not yet
+mapped as a Crossplane MR. See step 5 below to add a mapping.
+Crossplane Kinds ship in two API groups: `<group>.archestra.crossplane.io`
+(cluster-scoped, v1) and `<group>.archestra.m.crossplane.io`
+(namespaced, v2).
+
 ## 1. Build it
 
 ```bash
@@ -65,10 +96,10 @@ schema — skipping leads to phantom plan diffs and silent backend drift.
 
 ## 5. Expose it as a Crossplane MR (optional)
 
-If the resource should also be reachable from Crossplane:
+To pick up a `—` row in the coverage table above:
 
 1. Whitelist the TF resource name in `crossplane/config/external_name.go`.
-2. Add a configurator block in **both** `crossplane/config/cluster/<group>/config.go` and `.../namespaced/<group>/config.go` (v1 and v2 scopes).
+2. Add a configurator block in **both** `crossplane/config/cluster/<group>/config.go` and `.../namespaced/<group>/config.go` setting `r.ShortGroup` (becomes `<group>.archestra.crossplane.io`) and `r.Kind` (CamelCase singular).
 3. `make -C crossplane generate` — upjet regenerates apis, controllers, and CRDs.
 
 Local controller run, `make e2e`, and the full walkthrough are in

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ through extending the provider.
 
 ## Resource coverage
 
-| Terraform resource | Crossplane Kind |
+| Terraform | Crossplane Kind |
 |---|---|
 | `archestra_agent` | `Agent` |
 | `archestra_agent_tool` | — |
@@ -35,12 +35,20 @@ through extending the provider.
 | `archestra_tool_policy_auto_config` | — |
 | `archestra_trusted_data_policy` | — |
 | `archestra_trusted_data_policy_default` | — |
+| `data.archestra_agent_tool` | n/a |
+| `data.archestra_agent_tools` | n/a |
+| `data.archestra_mcp_server_tool` | n/a |
+| `data.archestra_mcp_tool_calls` | n/a |
+| `data.archestra_team` | n/a |
+| `data.archestra_team_external_groups` | n/a |
+| `data.archestra_tool` | n/a |
 
-`—` means the resource is implemented for Terraform but not yet
-mapped as a Crossplane MR. See step 5 below to add a mapping.
-Crossplane Kinds ship in two API groups: `<group>.archestra.crossplane.io`
-(cluster-scoped, v1) and `<group>.archestra.m.crossplane.io`
-(namespaced, v2).
+- `—` — TF resource exists, no Crossplane MR yet. See step 5 below.
+- `n/a` — TF data source. Crossplane has no read-only Managed Resource concept, so nothing to map.
+
+Crossplane Kinds ship in two API groups:
+`<group>.archestra.crossplane.io` (cluster-scoped, v1) and
+`<group>.archestra.m.crossplane.io` (namespaced, v2).
 
 ## 1. Build it
 


### PR DESCRIPTION
Adds a top-of-README \"Resource coverage\" table listing every Terraform resource and, beside it, the Crossplane Kind it's exposed as (or \`—\` if it isn't yet). 5/20 covered today.

Scanning the second column gives you the open work — the 15 \`—\` rows.

Step 5 (\"Expose it as a Crossplane MR\") now points back at the table and just shows the per-resource recipe, not the list.